### PR TITLE
Allow autohiding scrollbars in Microsoft Edge

### DIFF
--- a/src/app/assets/styles/common.scss
+++ b/src/app/assets/styles/common.scss
@@ -60,6 +60,7 @@ img {
     display: flex;
     flex-direction: column;
     width: 100%;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
   }
 
   #main-wrapper {


### PR DESCRIPTION
Scrollbars do not hide in Microsoft edge which kills the looks of the page a bit. See here: https://imgur.com/a/RZ7PqMb. Admittedly web-dev is not my strongest area so there may be a better location for this addition to the css, but it helps the looks on Edge considerably. 