### PR TITLE
Revert "Blur content when modal is opened"; this kills Safari.

### DIFF
--- a/src/app/components/App.jsx
+++ b/src/app/components/App.jsx
@@ -74,7 +74,6 @@ class App extends React.Component {
     };
 
     const modalState = {
-      opened: this.state.modalsContents.length >= 1,
       push: (content, style = {}) =>
         this.setState(state => ({
           modalsContents: [{ content, style }, ...state.modalsContents],

--- a/src/app/components/Common/PageContent/PageContent.jsx
+++ b/src/app/components/Common/PageContent/PageContent.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import cx from 'classnames';
 import classes from './PageContent.scss';
-import ModalContext from '../Modal/ModalContext';
 
 export default class PageContent extends React.Component {
   constructor(props) {
@@ -27,17 +25,9 @@ export default class PageContent extends React.Component {
     const { mounted } = this.state;
 
     return (
-      <ModalContext.Consumer>
-        {({ opened }) => (
-          <div
-            className={cx(classes.pageContent, { [classes.blurred]: opened })}
-            ref={innerRef}
-            {...rest}
-          >
-            {mounted && this.props.children}
-          </div>
-        )}
-      </ModalContext.Consumer>
+      <div className={classes.pageContent} ref={innerRef} {...rest}>
+        {mounted && this.props.children}
+      </div>
     );
   }
 }

--- a/src/app/components/Common/PageContent/PageContent.scss
+++ b/src/app/components/Common/PageContent/PageContent.scss
@@ -3,11 +3,6 @@
   flex: 1;
   overflow: auto;
 
-  &.blurred {
-    -webkit-filter: blur(6px) saturate(175%);
-    filter: blur(6px) saturate(175%);
-  }
-
   > h1, h2, h3, h3, h4, h5 {
     margin: 15px 0 5px 0;
   }


### PR DESCRIPTION
Reverts Musish/Musish#260.

Lets do this again properly later on, Safari can use -webkit-backdrop-filter on the modal container instead of the filter on the page content.