### PR TITLE
Update ArtistsList.jsx

### DIFF
--- a/src/app/components/Inside/Pages/Library/Artists/ArtistsList.jsx
+++ b/src/app/components/Inside/Pages/Library/Artists/ArtistsList.jsx
@@ -37,7 +37,7 @@ class ArtistsList extends React.Component {
                 </span>
               </div>
               <div>
-                <span className={classes.artistName}>{artist.attributes.name}</span>
+                <div className={classes.artistName}>{artist.attributes.name}</div>
               </div>
             </Link>
           )}

--- a/src/app/utils/translations/languages/French.json
+++ b/src/app/utils/translations/languages/French.json
@@ -31,7 +31,7 @@
   "heavyRotation": "En boucle",
 
   "browse": "Parcourir",
-  "topCharts": "Classement",
+  "topCharts": "Classements",
   "genres": "Genres",
   "topSongs": "Chansons",
   "dailyTop100": "Le top 100 du jour",


### PR DESCRIPTION
changing span to a div seems to fix the multi-line long artists offset bug

before
<img width="172" alt="musish1" src="https://user-images.githubusercontent.com/25106533/51994224-a30ea200-24b0-11e9-8d92-c1cf0f682a94.PNG">

after
<img width="159" alt="musish2" src="https://user-images.githubusercontent.com/25106533/51994225-a30ea200-24b0-11e9-94d8-c2268bdb5825.PNG">

