### PR TITLE
Fix Italian translation

### DIFF
--- a/src/app/utils/translations/languages/Italian.json
+++ b/src/app/utils/translations/languages/Italian.json
@@ -11,10 +11,10 @@
   "login": "Login",
   "searchMusic": "Cerca musica",
 
-  "play": "Play",
+  "play": "Riproduci",
   "playNext": "Riproduci come successiva",
   "playLater": "Riproduci in seguito",
-  "shuffle": "Riproduzione casuale",
+  "shuffle": "Casuale",
   "search": "Cerca",
   "searchingFor": "Cerca {0}",
 


### PR DESCRIPTION
Change one translation that was different from iTunes' one and one that was too long and didn't fit in the button.