### PR TITLE
Corrected GitHub brand name

### DIFF
--- a/src/app/components/Inside/Sidebar/Sidebar.jsx
+++ b/src/app/components/Inside/Sidebar/Sidebar.jsx
@@ -92,7 +92,7 @@ class Sidebar extends React.Component {
               </a>
               {' & '}
               <a href={'https://github.com/Musish/Musish'} target={'_blank'}>
-                Github
+                GitHub
               </a>
             </span>
             <span className={classes.footnote}>


### PR DESCRIPTION
Corrects the brand name capitalisation of GitHub.

From [GitHub Facts](https://github.com/about/facts) (emphasis mine):
> **GitHub** is the developer company.

About as nitpicky as it gets but I notice it every time I scroll to the bottom of the sidebar.