### PR TITLE
Musish logo link depending if you're logged in

### DIFF
--- a/src/app/components/Inside/NavigationBar/NavigationBar.jsx
+++ b/src/app/components/Inside/NavigationBar/NavigationBar.jsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import cx from 'classnames';
+import PropTypes from 'prop-types';
 import classes from './NavigationBar.scss';
 import SearchBar from './Search/SearchBar';
 import Authorize from './Authorize/Authorize';
 import Settings from './Settings/Settings';
+import AuthorizeContext from './Authorize/AuthorizeContext';
+import withContext from '../../../hoc/withContext';
 
-export default function NavigationBar() {
+function NavigationBar(props) {
   return (
     <nav className={classes.navigationBar}>
       <h1 className={classes.brand}>
-        <Link to="/">
+        <Link to={props.authorized ? '/' : '/browse'}>
           <span className={cx(classes.icon, 'musicon musicon-logo')} />
           <span className={classes.name}>Musish</span>
         </Link>
@@ -22,3 +25,9 @@ export default function NavigationBar() {
     </nav>
   );
 }
+
+NavigationBar.propTypes = {
+  authorized: PropTypes.bool.isRequired,
+};
+
+export default withContext(NavigationBar, AuthorizeContext);


### PR DESCRIPTION
Fixes #312 by having logo link set to

- `Browse` if you're logged out
- `For you` if you're logged in