### PR TITLE
Display playlists on artist page

### DIFF
--- a/src/app/components/Inside/Pages/Catalog/Artist/ArtistPage.jsx
+++ b/src/app/components/Inside/Pages/Catalog/Artist/ArtistPage.jsx
@@ -153,7 +153,7 @@ class ArtistPage extends React.Component {
         {geniusData && geniusData.plainDescription}
 
         {albums && (
-          <div>
+          <>
             <h3>{translate.albums}</h3>
 
             <div className={classes.albumsGrid}>
@@ -161,11 +161,11 @@ class ArtistPage extends React.Component {
                 <AlbumItem key={album.id} album={album} size={120} />
               ))}
             </div>
-          </div>
+          </>
         )}
 
         {playlists && (
-          <div>
+          <>
             <h3>{translate.playlists}</h3>
 
             <div className={classes.playlistsGrid}>
@@ -173,7 +173,7 @@ class ArtistPage extends React.Component {
                 <PlaylistItem key={playlist.id} playlist={playlist} size={120} />
               ))}
             </div>
-          </div>
+          </>
         )}
       </PageContent>
     );

--- a/src/app/components/Inside/Pages/Catalog/Artist/ArtistPage.jsx
+++ b/src/app/components/Inside/Pages/Catalog/Artist/ArtistPage.jsx
@@ -7,6 +7,7 @@ import PageContent from '../../../../Common/PageContent/PageContent';
 import AlbumItem from '../../../../Common/AlbumItem/AlbumItem';
 import backend from '../../../../../services/Backend';
 import translate from '../../../../../utils/translations/Translations';
+import PlaylistItem from '../../../../Common/PlaylistItem/PlaylistItem';
 
 class ArtistPage extends React.Component {
   constructor(props) {
@@ -54,6 +55,22 @@ class ArtistPage extends React.Component {
     });
   }
 
+  async fetchPlaylists() {
+    const music = MusicKit.getInstance();
+
+    const { id } = this.props.match.params;
+    const isCatalog = /^\d+$/.test(id);
+
+    let playlists;
+    if (isCatalog) {
+      playlists = await music.api.artist(id, { include: 'playlists' });
+    }
+
+    this.setState({
+      playlists,
+    });
+  }
+
   async fetchGeniusData() {
     const { id } = this.props.match.params;
 
@@ -94,6 +111,7 @@ class ArtistPage extends React.Component {
   componentDidMount() {
     this.fetchArtist();
     this.fetchAlbums();
+    this.fetchPlaylists();
     this.fetchGeniusData();
   }
 
@@ -101,12 +119,13 @@ class ArtistPage extends React.Component {
     if (this.state.artist && this.state.artist.id !== this.props.match.params.id) {
       this.fetchArtist();
       this.fetchAlbums();
+      this.fetchPlaylists();
       this.fetchGeniusData();
     }
   }
 
   render() {
-    const { artist, albums, geniusData } = this.state;
+    const { artist, albums, playlists, geniusData } = this.state;
 
     const headerStyles = {
       background: geniusData ? `url(${geniusData.header_image_url})` : '#f2f2f2',
@@ -132,13 +151,28 @@ class ArtistPage extends React.Component {
 
         <PageTitle title={artist ? artist.attributes.name : '...'} context={'Apple Music'} />
         {geniusData && geniusData.plainDescription}
-        <h3>{translate.albums}</h3>
 
         {albums && (
-          <div className={classes.albumsGrid}>
-            {albums.map(album => (
-              <AlbumItem key={album.id} album={album} size={120} />
-            ))}
+          <div>
+            <h3>{translate.albums}</h3>
+
+            <div className={classes.albumsGrid}>
+              {albums.map(album => (
+                <AlbumItem key={album.id} album={album} size={120} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {playlists && (
+          <div>
+            <h3>{translate.playlists}</h3>
+
+            <div className={classes.playlistsGrid}>
+              {playlists.map(playlist => (
+                <PlaylistItem key={playlist.id} playlist={playlist} size={120} />
+              ))}
+            </div>
           </div>
         )}
       </PageContent>

--- a/src/app/components/Inside/Pages/Catalog/Artist/ArtistPage.scss
+++ b/src/app/components/Inside/Pages/Catalog/Artist/ArtistPage.scss
@@ -1,6 +1,7 @@
 @import '../../../../../assets/styles/settings/colors';
 
-.albumsGrid {
+.albumsGrid,
+.playlistsGrid {
   display: flex;
   flex-wrap: wrap;
 


### PR DESCRIPTION
Fixes #318.
This feature will display the playlists for artists that exists on Apple Music.

![image](https://user-images.githubusercontent.com/438308/54514376-a8418680-4962-11e9-98d6-e80a5e6f104b.png)
