### PR TITLE
Fixed unnecessary nested scrollbars(Firefox), locked scrollbars(Edge) in "For You" screen

### DIFF
--- a/src/app/components/Inside/Pages/Catalog/ForYou/ForYouPage.scss
+++ b/src/app/components/Inside/Pages/Catalog/ForYou/ForYouPage.scss
@@ -32,7 +32,7 @@
 
 
 .scrollWrapper {
-  overflow: scroll;
+  overflow: auto;
 
   &::-webkit-scrollbar {
     width: 3px;


### PR DESCRIPTION
Fixes #235 
Before(Firefox 66): A lot of unnecessary scrollbars
![Screenshot_2019-03-28 Musish](https://user-images.githubusercontent.com/11980274/55117224-39a7ba00-5114-11e9-915c-ccd4291b2721.png)
After(Firefox 66):
![Screenshot_2019-03-28 Musish(1)](https://user-images.githubusercontent.com/11980274/55117242-4f1ce400-5114-11e9-9777-ef2188f240d6.png)

Before(Edge): The horizontal scrollbar is locked
![before](https://user-images.githubusercontent.com/11980274/55117478-3234e080-5115-11e9-85a3-46de92e3fcf3.png)
After(Edge):
![after](https://user-images.githubusercontent.com/11980274/55117483-3b25b200-5115-11e9-9614-08d228e2612e.png)
