### PR TITLE
Fix stretching of non-square images

### DIFF
--- a/src/app/components/Common/AlbumPanel/AlbumPanel.scss
+++ b/src/app/components/Common/AlbumPanel/AlbumPanel.scss
@@ -50,6 +50,7 @@
         border-radius: inherit;
         width: inherit;
         height: inherit;
+        object-fit:contain;
       }
     }
     

--- a/src/app/components/Common/ArtistItem/ArtistItem.scss
+++ b/src/app/components/Common/ArtistItem/ArtistItem.scss
@@ -32,6 +32,7 @@
 
     > img {
       border-radius: inherit;
+      object-fit: contain;
     }
 
     > span {

--- a/src/app/components/Common/ContextMenu/Types/Album/AlbumContextMenu.scss
+++ b/src/app/components/Common/ContextMenu/Types/Album/AlbumContextMenu.scss
@@ -19,6 +19,7 @@
         width: inherit;
         height: inherit;
         border-radius: inherit;
+        object-fit: contain;
       }
     }
   }

--- a/src/app/components/Common/ContextMenu/Types/Playlist/PlaylistContextMenu.scss
+++ b/src/app/components/Common/ContextMenu/Types/Playlist/PlaylistContextMenu.scss
@@ -19,6 +19,7 @@
         width: inherit;
         height: inherit;
         border-radius: inherit;
+        object-fit: contain;
       }
     }
   }

--- a/src/app/components/Common/ContextMenu/Types/Track/TrackContextMenu.scss
+++ b/src/app/components/Common/ContextMenu/Types/Track/TrackContextMenu.scss
@@ -19,6 +19,7 @@
         width: inherit;
         height: inherit;
         border-radius: inherit;
+        object-fit: contain;
       }
     }
   }

--- a/src/app/components/Common/PlaylistPanel/PlaylistPanel.scss
+++ b/src/app/components/Common/PlaylistPanel/PlaylistPanel.scss
@@ -25,6 +25,7 @@
           border-radius: inherit;
           width: inherit;
           height: inherit;
+          object-fit: contain;
         }
       }
 

--- a/src/app/components/Common/Tracks/TracksList/TrackDecoration.scss
+++ b/src/app/components/Common/Tracks/TracksList/TrackDecoration.scss
@@ -90,6 +90,7 @@
       border-radius: inherit;
       width: inherit;
       height: inherit;
+      object-fit: contain;
     }
   }
 }

--- a/src/app/components/Inside/Pages/Library/Artists/ArtistsPage.scss
+++ b/src/app/components/Inside/Pages/Library/Artists/ArtistsPage.scss
@@ -99,6 +99,7 @@
 
         > img {
           border-radius: inherit;
+          object-fit: contain;
         }
 
         > span {

--- a/src/app/components/Inside/Pages/Library/Playlist/PlaylistPage.scss
+++ b/src/app/components/Inside/Pages/Library/Playlist/PlaylistPage.scss
@@ -17,6 +17,7 @@
         border-radius: inherit;
         width: inherit;
         height: inherit;
+        object-fit: contain;
       }
     }
 

--- a/src/app/components/Inside/Player/Player.scss
+++ b/src/app/components/Inside/Player/Player.scss
@@ -17,6 +17,7 @@
         width: 60px;
         height: 60px;
         border-radius: inherit;
+        object-fit: contain;
       }
     }
 

--- a/src/app/components/Inside/Player/Queue/Queue.scss
+++ b/src/app/components/Inside/Player/Queue/Queue.scss
@@ -127,6 +127,7 @@
         border-radius: inherit;
         width: inherit;
         height: inherit;
+        object-fit: contain;
       }
     }
   }


### PR DESCRIPTION
Fixes #302 using `object-fit`, works on all [modern browsers](https://caniuse.com/#search=object-fit).
Example before:
![Screenshot_2019-04-17 Musish](https://user-images.githubusercontent.com/11980274/56304819-b8ff3b00-6160-11e9-8157-dab4cc49af12.png)
Example after:
![Screenshot_2019-04-17 Musish(1)](https://user-images.githubusercontent.com/11980274/56304830-bef51c00-6160-11e9-9222-45f53363b5a8.png)

