### PR TITLE
Add support for media keys

### DIFF
--- a/src/app/components/Common/Player/Player.tsx
+++ b/src/app/components/Common/Player/Player.tsx
@@ -44,10 +44,23 @@ class Player extends React.Component<PlayerProps> {
       'keydown',
     );
 
+    // Extend Mousetrap to support media keys
+    Mousetrap.addKeycodes({
+      176: 'nexttrack',
+      177: 'previoustrack',
+      178: 'stop',
+      179: 'playpause',
+    });
+
     // Playback controls
     Mousetrap.bind('left', this.handlePrevious, 'keyup');
     Mousetrap.bind('right', this.handleNext, 'keyup');
     Mousetrap.bind('space', togglePlayback, 'keyup');
+
+    Mousetrap.bind('previoustrack', this.handlePrevious, 'keyup');
+    Mousetrap.bind('nexttrack', this.handleNext, 'keyup');
+    Mousetrap.bind('playpause', togglePlayback, 'keyup');
+    Mousetrap.bind('stop', pause, 'keyup');
   }
 
   public handlePrevious = () => {

--- a/src/app/components/Common/Player/VolumeControl.tsx
+++ b/src/app/components/Common/Player/VolumeControl.tsx
@@ -20,6 +20,32 @@ class VolumeControl extends React.Component<VolumeControlProps, VolumeControlSta
   }
 
   public componentDidMount() {
+    // Extend Mousetrap to support media keys
+    Mousetrap.addKeycodes({
+      173: 'mute',
+      174: 'volumedown',
+      175: 'volumeup',
+    });
+
+    Mousetrap.bind(
+      'mute',
+      e => {
+        this.toggleVolume();
+      },
+      'keyup',
+    );
+
+    // Volume controls (VOLUME UP)
+    Mousetrap.bind(
+      'volumeup',
+      e => {
+        const { player } = MusicKit.getInstance();
+        const newVolume = player.volume < 0.9 ? player.volume + 0.1 : 1;
+        this.changeVolume(newVolume);
+      },
+      'keydown',
+    );
+
     // Volume controls (VOLUME UP)
     Mousetrap.bind(
       'up',
@@ -27,6 +53,17 @@ class VolumeControl extends React.Component<VolumeControlProps, VolumeControlSta
         e.preventDefault();
         const { player } = MusicKit.getInstance();
         const newVolume = player.volume < 0.9 ? player.volume + 0.1 : 1;
+        this.changeVolume(newVolume);
+      },
+      'keydown',
+    );
+
+    // Volume controls (VOLUME DOWN)
+    Mousetrap.bind(
+      'volumedown',
+      e => {
+        const { player } = MusicKit.getInstance();
+        const newVolume = player.volume > 0.1 ? player.volume - 0.1 : 0;
         this.changeVolume(newVolume);
       },
       'keydown',


### PR DESCRIPTION
Add support for media keys by adding their codes to Mousetrap and binding them to the proper events.

I wasn't able to test this as I wasn't able to get a local setup working :(. Hoping someone can pull and test as part of the review, or some feel free to takeover entirely. I also apologize in advance for any syntax errors, as I don't know typescript very well.