### PR TITLE
Allow app to crash silently when album artwork url doesnt exist

### DIFF
--- a/src/app/components/Common/AlbumItem/AlbumItem.tsx
+++ b/src/app/components/Common/AlbumItem/AlbumItem.tsx
@@ -33,7 +33,12 @@ const AlbumItem: React.FC<AlbumItemProps> = (props: AlbumItemProps) => {
   }
 
   const { album, size, connectDragSource, isOver } = props;
-  const artwork = MusicKit.formatArtworkURL(album.attributes.artwork, size, size);
+  let artwork;
+  try {
+    artwork = MusicKit.formatArtworkURL(album.attributes.artwork, size, size);
+  } catch (e) {
+    artwork = `https://is1-ssl.mzstatic.com/image/thumb/Features127/v4/75/f9/6f/75f96fa5-99ca-0854-3aae-8f76f5cb7fb5/source/${size}x${size}bb.jpeg`;
+  }
 
   const explicit = album.attributes.contentRating === 'explicit' && (
     <div className={classes.explicit}>


### PR DESCRIPTION
When ever you try to access a artwork url of a album and the property doesn't exists , the app just crashes. This patch allows the app crash silently by using try catch.

Error Message on macOS Catalina 10.15.1 ( Chrome 78.0.3904.108（Official Build))

<img width="1635" alt="スクリーンショット 2019-12-01 21 44 50" src="https://user-images.githubusercontent.com/26432452/69914130-e98fad00-1483-11ea-82b1-c042128218d7.png">
