### PR TITLE
Fix lyrics popup not being draggable

### DIFF
--- a/src/app/components/Common/Player/Lyrics/LyricsModal.tsx
+++ b/src/app/components/Common/Player/Lyrics/LyricsModal.tsx
@@ -23,9 +23,9 @@ function LyricsModal() {
   const nowPlaying = getPlayingItem();
 
   return (
-    <Draggable handle={queueClasses.header} defaultPosition={{ x: 0, y: 0 }}>
+    <Draggable handle={'.handle'} defaultPosition={{ x: 0, y: 0 }}>
       <div className={cx(queueClasses.modal, classes.modal)} onClick={e => e.stopPropagation()}>
-        <div className={cx(queueClasses.header)}>
+        <div className={cx(queueClasses.header, 'handle')}>
           <div className={queueClasses.title}>
             <span>
               <i className='fas fa-grip-vertical' />

--- a/src/app/components/Common/Player/Lyrics/LyricsModal.tsx
+++ b/src/app/components/Common/Player/Lyrics/LyricsModal.tsx
@@ -23,9 +23,9 @@ function LyricsModal() {
   const nowPlaying = getPlayingItem();
 
   return (
-    <Draggable handle={'.handle'} defaultPosition={{ x: 0, y: 0 }}>
+    <Draggable handle={'.lyricsHandle'} defaultPosition={{ x: 0, y: 0 }}>
       <div className={cx(queueClasses.modal, classes.modal)} onClick={e => e.stopPropagation()}>
-        <div className={cx(queueClasses.header, 'handle')}>
+        <div className={cx(queueClasses.header, 'lyricsHandle')}>
           <div className={queueClasses.title}>
             <span>
               <i className='fas fa-grip-vertical' />


### PR DESCRIPTION
The `handle` prop of `Draggable` evaluated to `header` while the lyrics-popup title bar's selector was `.header`.
Because of this mismatch, `Draggable` could find no connection to a selector, and no element was draggable.

This fix tells `Draggable` to look for the `handle` class that has been added to the title bar.