### PR TITLE
Feature: Cross browser styled scrollbars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,4 +76,6 @@ node_modules/
 secrets.json
 *.scss.d.ts
 
+# Log-files
 yarn-error.log
+report.*.json

--- a/src/app/assets/styles/common.scss
+++ b/src/app/assets/styles/common.scss
@@ -98,6 +98,15 @@ img {
   &:hover {
     scrollbar-color: lighten($accent_color, 25%) $background_color;
   }
+
+  &-thick {
+    @extend .scrollWrapper;
+    &::-webkit-scrollbar {
+      width: 9px;
+      height: 9px;
+    }
+    scrollbar-width: unset; // Firefox specific
+  }
 }
 
 :global {

--- a/src/app/assets/styles/common.scss
+++ b/src/app/assets/styles/common.scss
@@ -64,8 +64,8 @@ img {
   overflow: auto;
 
   &::-webkit-scrollbar {
-    width: 4px;
-    height: 4px;
+    width: 7px;
+    height: 7px;
     border-radius: 2px;
   }
 
@@ -106,7 +106,16 @@ img {
     scrollbar-color: lighten($accent_color, 18%) $background_color;
   }
 
-  &-thick {
+  &Thin {
+    @extend .scrollWrapper;
+    &::-webkit-scrollbar {
+      width: 4px;
+      height: 4px;
+    }
+    scrollbar-width: thin; // Firefox specific
+  }
+
+  &Thick {
     @extend .scrollWrapper;
     &::-webkit-scrollbar {
       width: 9px;

--- a/src/app/assets/styles/common.scss
+++ b/src/app/assets/styles/common.scss
@@ -88,6 +88,10 @@ img {
     background: lighten($accent_color, 25%);
   }
 
+  &::-webkit-scrollbar-thumb:active {
+    background: lighten($accent_color, 18%);
+  }
+
   &::-webkit-scrollbar-corner {
     display: none;
   }
@@ -97,6 +101,9 @@ img {
   scrollbar-color: lighten($accent_color, 40%) $background_color;
   &:hover {
     scrollbar-color: lighten($accent_color, 25%) $background_color;
+  }
+  &:active {
+    scrollbar-color: lighten($accent_color, 18%) $background_color;
   }
 
   &-thick {

--- a/src/app/assets/styles/common.scss
+++ b/src/app/assets/styles/common.scss
@@ -64,19 +64,19 @@ img {
   overflow: auto;
 
   &::-webkit-scrollbar {
-    width: 3px;
-    height: 3px;
-    border-radius: 1px;
+    width: 4px;
+    height: 4px;
+    border-radius: 2px;
   }
 
   &::-webkit-scrollbar-track {
     background: $background_color;
-    border-radius: 1px;
+    border-radius: 2px;
   }
 
   &::-webkit-scrollbar-thumb {
     background: lighten($accent_color, 40%);
-    border-radius: 1px;
+    border-radius: 2px;
     cursor: pointer;
   }
 

--- a/src/app/assets/styles/common.scss
+++ b/src/app/assets/styles/common.scss
@@ -66,17 +66,17 @@ img {
   &::-webkit-scrollbar {
     width: 7px;
     height: 7px;
-    border-radius: 2px;
+    border-radius: 99px;
   }
 
   &::-webkit-scrollbar-track {
     background: $background_color;
-    border-radius: 2px;
+    border-radius: 99px;
   }
 
   &::-webkit-scrollbar-thumb {
     background: lighten($accent_color, 40%);
-    border-radius: 2px;
+    border-radius: 99px;
     cursor: pointer;
   }
 

--- a/src/app/assets/styles/common.scss
+++ b/src/app/assets/styles/common.scss
@@ -17,7 +17,8 @@ body {
   box-sizing: border-box;
 }
 
-div, span {
+div,
+span {
   user-select: none;
   -webkit-user-select: none;
   -ms-user-select: none;
@@ -35,7 +36,12 @@ a:hover {
   color: #fe2851;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   margin: 0;
 }
 
@@ -52,6 +58,46 @@ button {
 img {
   user-drag: none;
   -webkit-user-drag: none;
+}
+
+.scrollWrapper {
+  overflow: auto;
+
+  &::-webkit-scrollbar {
+    width: 3px;
+    height: 3px;
+    border-radius: 1px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: $background_color;
+    border-radius: 1px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: lighten($accent_color, 40%);
+    border-radius: 1px;
+    cursor: pointer;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: $background_color;
+  }
+
+  &:hover::-webkit-scrollbar-thumb {
+    background: lighten($accent_color, 25%);
+  }
+
+  &::-webkit-scrollbar-corner {
+    display: none;
+  }
+
+  // Firefox specific
+  scrollbar-width: thin;
+  scrollbar-color: lighten($accent_color, 40%) $background_color;
+  &:hover {
+    scrollbar-color: lighten($accent_color, 25%) $background_color;
+  }
 }
 
 :global {

--- a/src/app/components/Common/Modal/Modal.scss
+++ b/src/app/components/Common/Modal/Modal.scss
@@ -16,7 +16,7 @@
   animation: fadein 0.1s ease-out;
 
   .modal {
-    @extend .scrollWrapper-thick;
+    @extend .scrollWrapper;
 
     width: 70%;
     max-width: 900px;

--- a/src/app/components/Common/Modal/Modal.scss
+++ b/src/app/components/Common/Modal/Modal.scss
@@ -15,18 +15,22 @@
   align-items: center;
   animation: fadein 0.1s ease-out;
 
-  .modal {
-    @extend .scrollWrapper;
-
+  .modalWrapper {
     width: 70%;
     max-width: 900px;
-    max-height: 80%;
-    padding: 20px 25px;
-    overflow: auto;
+    height: 80%;
+    padding: 9px;
     background: $background_color;
     border-radius: 8px;
     box-shadow: 0 8px 36px -10px rgba(150, 150, 150, 0.75);
     animation: fadein 0.1s;
+  }
+
+  .modal {
+    @extend .scrollWrapper;
+
+    height: 100%;
+    padding: 12px 12px 12px 17px;
   }
 }
 

--- a/src/app/components/Common/Modal/Modal.scss
+++ b/src/app/components/Common/Modal/Modal.scss
@@ -1,3 +1,4 @@
+@import '../../../assets/styles/common.scss';
 @import '../../../assets/styles/settings/colors';
 
 .container {
@@ -15,6 +16,8 @@
   animation: fadein 0.1s ease-out;
 
   .modal {
+    @extend .scrollWrapper-thick;
+
     width: 70%;
     max-width: 900px;
     max-height: 80%;
@@ -28,6 +31,10 @@
 }
 
 @keyframes fadein {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }

--- a/src/app/components/Common/Modal/Modal.tsx
+++ b/src/app/components/Common/Modal/Modal.tsx
@@ -18,8 +18,10 @@ function Modal(props: ModalProps) {
 
   return (
     <div className={classes.container} onClick={props.handleClose}>
-      <div className={classes.modal} onClick={e => e.stopPropagation()} style={inlineStyles}>
-        {props.render()}
+      <div className={classes.modalWrapper}>
+        <div className={classes.modal} onClick={e => e.stopPropagation()} style={inlineStyles}>
+          {props.render()}
+        </div>
       </div>
     </div>
   );

--- a/src/app/components/Common/PageContent/PageContent.scss
+++ b/src/app/components/Common/PageContent/PageContent.scss
@@ -4,7 +4,7 @@
   @extend .scrollWrapperThick;
 
   // padding: 0 1.5em 15px;
-  margin: 10px 8px 9px 22px;
+  margin: 8px 8px 8px 22px;
   padding-right: 8px;
   flex: 1;
   overflow: auto;

--- a/src/app/components/Common/PageContent/PageContent.scss
+++ b/src/app/components/Common/PageContent/PageContent.scss
@@ -1,7 +1,7 @@
 @import '../../../assets/styles/common.scss';
 
 .pageContent {
-  @extend .scrollWrapper-thick;
+  @extend .scrollWrapperThick;
 
   padding: 0 1.5em 15px;
   flex: 1;

--- a/src/app/components/Common/PageContent/PageContent.scss
+++ b/src/app/components/Common/PageContent/PageContent.scss
@@ -1,9 +1,18 @@
+@import '../../../assets/styles/common.scss';
+
 .pageContent {
+  @extend .scrollWrapper-thick;
+
   padding: 0 1.5em 15px;
   flex: 1;
   overflow: auto;
 
-  > h1, h2, h3, h3, h4, h5 {
+  > h1,
+  h2,
+  h3,
+  h3,
+  h4,
+  h5 {
     margin: 15px 0 5px 0;
   }
 }

--- a/src/app/components/Common/PageContent/PageContent.scss
+++ b/src/app/components/Common/PageContent/PageContent.scss
@@ -3,7 +3,9 @@
 .pageContent {
   @extend .scrollWrapperThick;
 
-  padding: 0 1.5em 15px;
+  // padding: 0 1.5em 15px;
+  margin: 10px 8px 9px 22px;
+  padding-right: 8px;
   flex: 1;
   overflow: auto;
 

--- a/src/app/components/Common/Player/Lyrics/Lyrics.tsx
+++ b/src/app/components/Common/Player/Lyrics/Lyrics.tsx
@@ -15,17 +15,44 @@ const iframeCss = `
       margin: 0;
       padding: 0;
       font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Roboto', sans-serif;
-      scrollbar-color: #d4d4d4 #eee;
+
+      scrollbar-width: thin;
+      scrollbar-color: #ffa7b8 #fff;
   }
-  
+
+  html {
+    padding-right: 6px;
+  }
+
+  // :hover selector is not used because it behaves strangely in here
+
+  :active {
+    scrollbar-color: #fe839b #fff;
+  }
+
   ::-webkit-scrollbar {
-    width: 9px;
+    width: 7px;
+    height: 7px;
+    border-radius: 99px;
   }
+
   ::-webkit-scrollbar-track {
-    background: #eee;
+    background: #fff;
+    border-radius: 99px;
   }
+
   ::-webkit-scrollbar-thumb {
-    background: #d4d4d4;
+    background: #ffa7b8;
+    border-radius: 99px;
+    cursor: pointer;
+  }
+
+  ::-webkit-scrollbar-thumb:active {
+    background: #fe839b;
+  }
+
+  ::-webkit-scrollbar-corner {
+    display: none;
   }
 
   .rg_embed_body * {

--- a/src/app/components/Common/Player/Lyrics/Lyrics.tsx
+++ b/src/app/components/Common/Player/Lyrics/Lyrics.tsx
@@ -4,6 +4,10 @@ import translate from '../../../../utils/translations/Translations';
 import Loader from '../../Loader/Loader';
 import classes from './LyricsModal.scss';
 
+// It is not possible to assign CSS dynamically by traversing the DOM in Javascript, the iframe's child elements cannot be accessed.
+// It is also not possible to use the embedded content's class-names and assign properties to them in our own CSS files - these will not be applied.
+// Our only option seems to be to compile and enter CSS dynamically into the below variable.
+// Consider: "https://sass-lang.com/documentation/js-api"
 const iframeCss = `
 <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet">
 <style>
@@ -11,8 +15,19 @@ const iframeCss = `
       margin: 0;
       padding: 0;
       font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Roboto', sans-serif;
+      scrollbar-color: #d4d4d4 #eee;
   }
   
+  ::-webkit-scrollbar {
+    width: 9px;
+  }
+  ::-webkit-scrollbar-track {
+    background: #eee;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: #d4d4d4;
+  }
+
   .rg_embed_body * {
     background: none !important;
     color: #000 !important;

--- a/src/app/components/Common/Player/Lyrics/LyricsModal.scss
+++ b/src/app/components/Common/Player/Lyrics/LyricsModal.scss
@@ -1,4 +1,4 @@
-@import "../../../../assets/styles/settings/colors";
+@import '../../../../assets/styles/settings/colors';
 
 .modal {
   width: 400px;
@@ -7,7 +7,8 @@
 }
 
 .lyricsSection {
-  height: 455px;
+  height: 100%;
+  margin: 6px;
 }
 
 .noMatch {

--- a/src/app/components/Common/Player/Queue/Queue.scss
+++ b/src/app/components/Common/Player/Queue/Queue.scss
@@ -1,4 +1,5 @@
-@import "../../../../assets/styles/settings/colors";
+@import '../../../../assets/styles/common.scss';
+@import '../../../../assets/styles/settings/colors';
 
 .modal {
   position: absolute;
@@ -67,10 +68,12 @@
   }
 }
 
-.QueueList {
-  position: relative;
-  width: 400px;
-  padding: 0;
+.queueList {
+  @extend .scrollWrapper;
+
+  // position: relative;
+  // width: 400px;
+  // padding: 0;
 }
 
 .queueItem {
@@ -159,7 +162,7 @@
     > i {
       padding: 5px 5px;
       margin-right: 15px;
-      margin-left:5px;
+      margin-left: 5px;
       color: $background_color;
       cursor: pointer;
       transition: color 0.1s;

--- a/src/app/components/Common/Player/Queue/Queue.scss
+++ b/src/app/components/Common/Player/Queue/Queue.scss
@@ -5,8 +5,6 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 320px;
-  height: 400px;
   margin-top: -200px;
   margin-left: -137.5px;
   z-index: 2000;
@@ -68,12 +66,14 @@
   }
 }
 
+.queueListWrapper {
+  margin: 6px;
+}
+
 .queueList {
   @extend .scrollWrapper;
 
-  // position: relative;
-  // width: 400px;
-  // padding: 0;
+  padding-right: 6px;
 }
 
 .queueItem {
@@ -118,7 +118,7 @@
     align-items: center;
     position: relative;
     border-radius: 3px;
-    padding-left: 10px;
+    padding-left: 6px;
 
     .artworkWrapper {
       border-radius: 3px;
@@ -160,8 +160,7 @@
 
   .removeButton {
     > i {
-      padding: 5px 5px;
-      margin-right: 15px;
+      padding: 10px;
       margin-left: 5px;
       color: $background_color;
       cursor: pointer;

--- a/src/app/components/Common/Player/Queue/Queue.tsx
+++ b/src/app/components/Common/Player/Queue/Queue.tsx
@@ -72,12 +72,14 @@ class Queue extends React.Component<QueueProps> {
               </span>
             </div>
           </div>
-          <QueueList
-            onSortEnd={this.onSortEnd}
-            shouldCancelStart={Queue.shouldCancelStart}
-            helperClass={classes.sortableHelper}
-            removeItemFunc={this.removeItem}
-          />
+          <div className={classes.queueListWrapper}>
+            <QueueList
+              onSortEnd={this.onSortEnd}
+              shouldCancelStart={Queue.shouldCancelStart}
+              helperClass={classes.sortableHelper}
+              removeItemFunc={this.removeItem}
+            />
+          </div>
         </div>
       </Draggable>
     );

--- a/src/app/components/Common/Sidebar/Sidebar.scss
+++ b/src/app/components/Common/Sidebar/Sidebar.scss
@@ -20,6 +20,7 @@
     &::-webkit-scrollbar {
       display: none;
     }
+    scrollbar-width: none; // Firefox specific
 
     .menu {
       background: $background_color;

--- a/src/app/components/Common/Tracks/TracksGrid/TracksGrid.scss
+++ b/src/app/components/Common/Tracks/TracksGrid/TracksGrid.scss
@@ -1,41 +1,5 @@
 @import '../../../../assets/styles/settings/colors';
 
-.scrollWrapper {
-  overflow: auto;
-
-  &::-webkit-scrollbar {
-    width: 3px;
-    height: 3px;
-    border-radius: 1px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: $background_color;
-    border-radius: 1px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: lighten($accent_color, 40%);
-    border-radius: 1px;
-    cursor: pointer;
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background: $background_color;
-  }
-
-  &:hover::-webkit-scrollbar-thumb {
-    background: lighten($accent_color, 25%);
-  }
-
-  // Firefox specific
-  scrollbar-width: thin;
-  scrollbar-color: lighten($accent_color, 40%) $background_color;
-  &:hover {
-    scrollbar-color: lighten($accent_color, 25%) $background_color;
-  }
-}
-
 .trackGrid {
   display: grid;
   grid-auto-flow: column dense;

--- a/src/app/components/Common/Tracks/TracksGrid/TracksGrid.scss
+++ b/src/app/components/Common/Tracks/TracksGrid/TracksGrid.scss
@@ -27,6 +27,13 @@
   &:hover::-webkit-scrollbar-thumb {
     background: lighten($accent_color, 25%);
   }
+
+  // Firefox specific
+  scrollbar-width: thin;
+  scrollbar-color: lighten($accent_color, 40%) $background_color;
+  &:hover {
+    scrollbar-color: lighten($accent_color, 25%) $background_color;
+  }
 }
 
 .trackGrid {
@@ -42,7 +49,8 @@
     width: 350px;
     height: 50px;
 
-    &:nth-child(4n+1) > :first-child > :first-child:before  { // This is getting a little bit too "creative" now...
+    // This is getting a little bit too "creative" now...
+    &:nth-child(4n + 1) > :first-child > :first-child:before {
       display: none;
     }
   }

--- a/src/app/components/Common/Tracks/TracksGrid/TracksGrid.tsx
+++ b/src/app/components/Common/Tracks/TracksGrid/TracksGrid.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
 import TrackListItem from '../TracksList/TracksListItem';
-import * as classes from './TracksGrid.scss';
+import commonClasses from '../../../../assets/styles/common.scss';
+import classes from './TracksGrid.scss';
 
 interface TracksGridProps {
   showArtist?: boolean;
@@ -25,7 +26,7 @@ const TracksGrid: React.FC<TracksGridProps> = ({
   playTrack,
 }) => {
   return (
-    <div className={classes.scrollWrapper}>
+    <div className={commonClasses.scrollWrapper}>
       <div className={classes.trackGrid}>
         {tracks.map((track, index) => (
           <TrackListItem

--- a/src/app/components/Common/Tracks/TracksGrid/TracksGrid.tsx
+++ b/src/app/components/Common/Tracks/TracksGrid/TracksGrid.tsx
@@ -26,7 +26,7 @@ const TracksGrid: React.FC<TracksGridProps> = ({
   playTrack,
 }) => {
   return (
-    <div className={commonClasses.scrollWrapper}>
+    <div className={commonClasses.scrollWrapperThin}>
       <div className={classes.trackGrid}>
         {tracks.map((track, index) => (
           <TrackListItem

--- a/src/app/components/Common/Tracks/TracksGrid/TracksGrid.tsx
+++ b/src/app/components/Common/Tracks/TracksGrid/TracksGrid.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import TrackListItem from '../TracksList/TracksListItem';
 import commonClasses from '../../../../assets/styles/common.scss';
+import TrackListItem from '../TracksList/TracksListItem';
 import classes from './TracksGrid.scss';
 
 interface TracksGridProps {

--- a/src/app/components/Routes/Catalog/Browse/BrowsePage.scss
+++ b/src/app/components/Routes/Catalog/Browse/BrowsePage.scss
@@ -27,6 +27,13 @@
   &:hover::-webkit-scrollbar-thumb {
     background: lighten($accent_color, 25%);
   }
+
+  // Firefox specific
+  scrollbar-width: thin;
+  scrollbar-color: lighten($accent_color, 40%) $background_color;
+  &:hover {
+    scrollbar-color: lighten($accent_color, 25%) $background_color;
+  }
 }
 
 .scrollGrid {

--- a/src/app/components/Routes/Catalog/Browse/BrowsePage.scss
+++ b/src/app/components/Routes/Catalog/Browse/BrowsePage.scss
@@ -1,41 +1,5 @@
 @import '../../../../assets/styles/settings/colors';
 
-.scrollWrapper {
-  overflow: auto;
-
-  &::-webkit-scrollbar {
-    width: 3px;
-    height: 3px;
-    border-radius: 1px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: $background_color;
-    border-radius: 1px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: lighten($accent_color, 40%);
-    border-radius: 1px;
-    cursor: pointer;
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background: $background_color;
-  }
-
-  &:hover::-webkit-scrollbar-thumb {
-    background: lighten($accent_color, 25%);
-  }
-
-  // Firefox specific
-  scrollbar-width: thin;
-  scrollbar-color: lighten($accent_color, 40%) $background_color;
-  &:hover {
-    scrollbar-color: lighten($accent_color, 25%) $background_color;
-  }
-}
-
 .scrollGrid {
   display: grid;
   grid-auto-flow: column dense;

--- a/src/app/components/Routes/Catalog/Browse/ItemList.tsx
+++ b/src/app/components/Routes/Catalog/Browse/ItemList.tsx
@@ -70,7 +70,7 @@ const ItemList: React.FC<ItemListProps> = ({
   return (
     <>
       <h3>{title}</h3>
-      <div className={commonClasses.scrollWrapper}>
+      <div className={commonClasses.scrollWrapperThin}>
         <div className={cx(classes.scrollGrid)} style={styles}>
           {finalItems.map((item: MediaItem) => {
             switch (type) {

--- a/src/app/components/Routes/Catalog/Browse/ItemList.tsx
+++ b/src/app/components/Routes/Catalog/Browse/ItemList.tsx
@@ -3,6 +3,7 @@ import React, { ReactNode, useEffect, useState } from 'react';
 import AlbumItem from '../../../Common/AlbumItem/AlbumItem';
 import CuratorItem from '../../../Common/CuratorItem/CuratorItem';
 import PlaylistItem from '../../../Common/PlaylistItem/PlaylistItem';
+import commonClasses from '../../../../assets/styles/common.scss';
 import classes from './BrowsePage.scss';
 import MediaItem = MusicKit.MediaItem;
 import Resource = MusicKit.Resource;
@@ -69,7 +70,7 @@ const ItemList: React.FC<ItemListProps> = ({
   return (
     <>
       <h3>{title}</h3>
-      <div className={classes.scrollWrapper}>
+      <div className={commonClasses.scrollWrapper}>
         <div className={cx(classes.scrollGrid)} style={styles}>
           {finalItems.map((item: MediaItem) => {
             switch (type) {

--- a/src/app/components/Routes/Catalog/Browse/ItemList.tsx
+++ b/src/app/components/Routes/Catalog/Browse/ItemList.tsx
@@ -1,9 +1,9 @@
 import cx from 'classnames';
 import React, { ReactNode, useEffect, useState } from 'react';
+import commonClasses from '../../../../assets/styles/common.scss';
 import AlbumItem from '../../../Common/AlbumItem/AlbumItem';
 import CuratorItem from '../../../Common/CuratorItem/CuratorItem';
 import PlaylistItem from '../../../Common/PlaylistItem/PlaylistItem';
-import commonClasses from '../../../../assets/styles/common.scss';
 import classes from './BrowsePage.scss';
 import MediaItem = MusicKit.MediaItem;
 import Resource = MusicKit.Resource;

--- a/src/app/components/Routes/Catalog/ForYou/ForYouPage.scss
+++ b/src/app/components/Routes/Catalog/ForYou/ForYouPage.scss
@@ -1,4 +1,4 @@
-  @import '../../../../assets/styles/settings/colors';
+@import '../../../../assets/styles/settings/colors';
 
 .albumHeading {
   margin-top: 20px;
@@ -25,11 +25,10 @@
     justify-content: left;
 
     > * {
-      margin: 5px 5px
+      margin: 5px 5px;
     }
   }
 }
-
 
 .scrollWrapper {
   overflow: auto;
@@ -61,6 +60,13 @@
 
   &::-webkit-scrollbar-corner {
     display: none;
+  }
+
+  // Firefox specific
+  scrollbar-width: thin;
+  scrollbar-color: lighten($accent_color, 40%) $background_color;
+  &:hover {
+    scrollbar-color: lighten($accent_color, 25%) $background_color;
   }
 }
 

--- a/src/app/components/Routes/Catalog/ForYou/ForYouPage.scss
+++ b/src/app/components/Routes/Catalog/ForYou/ForYouPage.scss
@@ -30,46 +30,6 @@
   }
 }
 
-.scrollWrapper {
-  overflow: auto;
-
-  &::-webkit-scrollbar {
-    width: 3px;
-    height: 3px;
-    border-radius: 1px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: $background_color;
-    border-radius: 1px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: lighten($accent_color, 40%);
-    border-radius: 1px;
-    cursor: pointer;
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background: $accent_color;
-  }
-
-  &:hover::-webkit-scrollbar-thumb {
-    background: lighten($accent_color, 25%);
-  }
-
-  &::-webkit-scrollbar-corner {
-    display: none;
-  }
-
-  // Firefox specific
-  scrollbar-width: thin;
-  scrollbar-color: lighten($accent_color, 40%) $background_color;
-  &:hover {
-    scrollbar-color: lighten($accent_color, 25%) $background_color;
-  }
-}
-
 .scrollGrid {
   display: grid;
   grid-auto-flow: column dense;

--- a/src/app/components/Routes/Catalog/ForYou/ForYouPage.tsx
+++ b/src/app/components/Routes/Catalog/ForYou/ForYouPage.tsx
@@ -2,13 +2,13 @@ import cx from 'classnames';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 import { withRouter } from 'react-router-dom';
+import commonClasses from '../../../../assets/styles/common.scss';
 import translate from '../../../../utils/translations/Translations';
 import AlbumItem from '../../../Common/AlbumItem/AlbumItem';
 import Loader from '../../../Common/Loader/Loader';
 import PageContent from '../../../Common/PageContent/PageContent';
 import PageTitle from '../../../Common/PageTitle/PageTitle';
 import PlaylistItem from '../../../Common/PlaylistItem/PlaylistItem';
-import commonClasses from '../../../../assets/styles/common.scss';
 import classes from './ForYouPage.scss';
 
 type ForYouPageProps = RouteComponentProps;

--- a/src/app/components/Routes/Catalog/ForYou/ForYouPage.tsx
+++ b/src/app/components/Routes/Catalog/ForYou/ForYouPage.tsx
@@ -8,6 +8,7 @@ import Loader from '../../../Common/Loader/Loader';
 import PageContent from '../../../Common/PageContent/PageContent';
 import PageTitle from '../../../Common/PageTitle/PageTitle';
 import PlaylistItem from '../../../Common/PlaylistItem/PlaylistItem';
+import commonClasses from '../../../../assets/styles/common.scss';
 import classes from './ForYouPage.scss';
 
 type ForYouPageProps = RouteComponentProps;
@@ -82,7 +83,7 @@ class ForYouPage extends React.Component<ForYouPageProps, ForYouPageState> {
     return (
       <>
         <h3>{translate.recentlyPlayed}</h3>
-        <div className={cx(classes.scrollWrapper)}>
+        <div className={cx(commonClasses.scrollWrapper)}>
           <div className={classes.scrollGrid}>
             {recentlyPlayed.map((item: RecentlyPlayedItem) => {
               switch (item.type) {
@@ -114,7 +115,7 @@ class ForYouPage extends React.Component<ForYouPageProps, ForYouPageState> {
     return (
       <>
         <h3>{translate.heavyRotation}</h3>
-        <div className={classes.scrollWrapper}>
+        <div className={commonClasses.scrollWrapper}>
           <div className={classes.scrollGrid}>
             {heavyRotation.map((item: HeavyRotationItem) => {
               switch (item.type) {
@@ -165,8 +166,8 @@ class ForYouPage extends React.Component<ForYouPageProps, ForYouPageState> {
       return (
         <React.Fragment key={id}>
           <h3>{group.attributes.title.stringForDisplay}</h3>
-          <div className={cx(classes.scrollWrapper)}>
-            <div className={cx(classes.scrollWrapper)}>
+          <div className={cx(commonClasses.scrollWrapper)}>
+            <div className={cx(commonClasses.scrollWrapper)}>
               <div className={classes.scrollGrid}>
                 {items.data.map((item: RecommendationGroupItem) => {
                   switch (item.type) {

--- a/src/app/components/Routes/Catalog/ForYou/ForYouPage.tsx
+++ b/src/app/components/Routes/Catalog/ForYou/ForYouPage.tsx
@@ -83,7 +83,7 @@ class ForYouPage extends React.Component<ForYouPageProps, ForYouPageState> {
     return (
       <>
         <h3>{translate.recentlyPlayed}</h3>
-        <div className={cx(commonClasses.scrollWrapper)}>
+        <div className={cx(commonClasses.scrollWrapperThin)}>
           <div className={classes.scrollGrid}>
             {recentlyPlayed.map((item: RecentlyPlayedItem) => {
               switch (item.type) {
@@ -115,7 +115,7 @@ class ForYouPage extends React.Component<ForYouPageProps, ForYouPageState> {
     return (
       <>
         <h3>{translate.heavyRotation}</h3>
-        <div className={commonClasses.scrollWrapper}>
+        <div className={commonClasses.scrollWrapperThin}>
           <div className={classes.scrollGrid}>
             {heavyRotation.map((item: HeavyRotationItem) => {
               switch (item.type) {
@@ -166,8 +166,8 @@ class ForYouPage extends React.Component<ForYouPageProps, ForYouPageState> {
       return (
         <React.Fragment key={id}>
           <h3>{group.attributes.title.stringForDisplay}</h3>
-          <div className={cx(commonClasses.scrollWrapper)}>
-            <div className={cx(commonClasses.scrollWrapper)}>
+          <div className={cx(commonClasses.scrollWrapperThin)}>
+            <div className={cx(commonClasses.scrollWrapperThin)}>
               <div className={classes.scrollGrid}>
                 {items.data.map((item: RecommendationGroupItem) => {
                   switch (item.type) {

--- a/src/app/components/Routes/Library/Artists/ArtistsPage.scss
+++ b/src/app/components/Routes/Library/Artists/ArtistsPage.scss
@@ -12,7 +12,7 @@
 }
 
 .artistList {
-  @extend .scrollWrapper;
+  @extend .scrollWrapperThin;
 
   width: 250px;
   height: 100%;

--- a/src/app/components/Routes/Library/Artists/ArtistsPage.scss
+++ b/src/app/components/Routes/Library/Artists/ArtistsPage.scss
@@ -1,3 +1,4 @@
+@import '../../../../assets/styles/common.scss';
 @import '../../../../assets/styles/settings/colors';
 
 .container {
@@ -11,6 +12,8 @@
 }
 
 .artistList {
+  @extend .scrollWrapper;
+
   width: 250px;
   height: 100%;
   border-right: solid 1px $container_background;


### PR DESCRIPTION
### Replace all native-scrollbars with CSS-styled ones.
New scrollbars for:
- PageContent class (generic page wrapper)
- Modal class (for album popups)
- ArtistList class (list of artists saved to library)
- Embedded lyrics-popup (Genius lyrics iframe)
- Queue-popup (for songs in play-queue)

### Remove the class-specific scrollbar CSS properties and adds a single scrollbarWrapper class in common.scss.
Other SASS classes extend this class for its scrollbar-related properties.
This removes duplicate code and makes it easier to add custom scrollbar styling to future components.

### Add CSS properties for styling Firefox scrollbars.
Previous properties were all for webkit-powered browsers.
Firefox only supports very basic scrollbar properties and thus no corner-radius styling is possible.

### Make scrollbars slightly darker when pressed and held.
This adds visual feedback when scrolling by dragging the scrollbar.

### Increase the thickness of the narrowest webkit-scrollbars from 3 to 4px.
I personally found the horizontal scrollbars on the _For You_ and _Browse_ pages difficult to click with a mouse and I still think they look good at 4px, while being a little more accessible.
Such are the perils of not using trackspads and magic mice ;-)

#### Screenshots [here](https://github.com/Musish/Musish/pull/492#issuecomment-667672029).

___

#### P.S.
I have only had the chance to test these changes in Firefox and Chromium, so please let me know if something doesn't look right in Safari.