### PR TITLE
Filter out search results missing the `attributes` property.

### DIFF
--- a/src/app/components/Common/NavigationBar/Search/SearchBar.tsx
+++ b/src/app/components/Common/NavigationBar/Search/SearchBar.tsx
@@ -5,6 +5,7 @@ import { RouteComponentProps } from 'react-router';
 import { withRouter } from 'react-router-dom';
 import withMK from '../../../../hoc/withMK';
 import translate from '../../../../utils/translations/Translations';
+import { hasAttributes } from '../../../../utils/Utils';
 import Loader from '../../Loader/Loader';
 import AlbumResultItem from './AlbumResultItem';
 import ArtistResultItem from './ArtistResultItem';
@@ -132,8 +133,7 @@ class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
 
     const catalogItems = catalogData && catalogData[type] ? catalogData[type].data : [];
 
-    // Filter out invalid items returned from the API.
-    return [...libraryItems, ...catalogItems].filter(item => item.attributes !== undefined);
+    return [...libraryItems, ...catalogItems].filter(hasAttributes);
   };
 
   public renderType = (

--- a/src/app/components/Common/NavigationBar/Search/SearchBar.tsx
+++ b/src/app/components/Common/NavigationBar/Search/SearchBar.tsx
@@ -132,7 +132,8 @@ class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
 
     const catalogItems = catalogData && catalogData[type] ? catalogData[type].data : [];
 
-    return [...libraryItems, ...catalogItems];
+    // Filter out invalid items returned from the API.
+    return [...libraryItems, ...catalogItems].filter(item => item.attributes !== undefined);
   };
 
   public renderType = (

--- a/src/app/components/Routes/Catalog/ForYou/ForYouPage.tsx
+++ b/src/app/components/Routes/Catalog/ForYou/ForYouPage.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { RouteComponentProps } from 'react-router';
 import { withRouter } from 'react-router-dom';
 import translate from '../../../../utils/translations/Translations';
+import { hasAttributes } from '../../../../utils/Utils';
 import AlbumItem from '../../../Common/AlbumItem/AlbumItem';
 import Loader from '../../../Common/Loader/Loader';
 import PageContent from '../../../Common/PageContent/PageContent';
@@ -41,14 +42,14 @@ class ForYouPage extends React.Component<ForYouPageProps, ForYouPageState> {
 
     let heavyRotation;
     try {
-      heavyRotation = await music.api.historyHeavyRotation();
+      heavyRotation = (await music.api.historyHeavyRotation()).filter(hasAttributes);
     } catch (error) {
       heavyRotation = false;
     }
 
     let recentlyPlayed;
     try {
-      recentlyPlayed = await music.api.recentPlayed();
+      recentlyPlayed = (await music.api.recentPlayed()).filter(hasAttributes);
     } catch (error) {
       recentlyPlayed = false;
     }
@@ -56,7 +57,7 @@ class ForYouPage extends React.Component<ForYouPageProps, ForYouPageState> {
     let recommendations;
     try {
       // @ts-ignore Incorrect type signature
-      recommendations = await music.api.recommendations();
+      recommendations = (await music.api.recommendations()).filter(hasAttributes);
     } catch (error) {
       recommendations = false;
     }

--- a/src/app/utils/Utils.ts
+++ b/src/app/utils/Utils.ts
@@ -95,3 +95,8 @@ export const getRatingUrl = (type: string, id: any) => {
 export function setPseudoRoute(route: string) {
   window.history.pushState('', '', route);
 }
+
+// TODO: Replace this with comprehensive validation of API responses.
+export function hasAttributes(resource: any): boolean {
+  return !!resource.attributes;
+}


### PR DESCRIPTION
A simple sanity check to avoid crashing the page when the Apple Music API returns invalid results. This is a hotfix for #493.