### PR TITLE
Better Last.fm support

### DIFF
--- a/src/app/components/Providers/LastfmProvider.tsx
+++ b/src/app/components/Providers/LastfmProvider.tsx
@@ -79,12 +79,14 @@ const LastfmProvider: React.FC<LastfmProviderProps> = ({ children, mk }: LastfmP
             'timestamp[0]': Math.floor(Date.now() / 1000),
             'album[0]': item.albumName,
             'trackNumber[0]': item.trackNumber,
+            'duration[0]': Math.round(item.playbackDuration / 1000),
           }
         : {
             artist: item.artistName,
             track: item.title,
             album: item.albumName,
             trackNumber: item.trackNumber,
+            duration: Math.round(item.playbackDuration / 1000),
           };
 
     try {

--- a/src/app/components/Providers/LastfmProvider.tsx
+++ b/src/app/components/Providers/LastfmProvider.tsx
@@ -226,7 +226,9 @@ const LastfmProvider: React.FC<LastfmProviderProps> = ({ children, mk }: LastfmP
     // New track has started playin
     if (
       mk.mediaItem &&
-      trackStatus.current.id !== mk.mediaItem.item.id &&
+      (trackStatus.current.id !== mk.mediaItem.item.id ||
+        // Track is being repeated (either manually or automatically)
+        (mk.instance.player.currentPlaybackProgress === 0 && trackStatus.current.hasScrobbled)) &&
       mk.instance.player.isPlaying
     ) {
       trackStatus.current.id = mk.mediaItem.item.id;

--- a/src/app/components/Providers/LastfmProvider.tsx
+++ b/src/app/components/Providers/LastfmProvider.tsx
@@ -163,7 +163,7 @@ const LastfmProvider: React.FC<LastfmProviderProps> = ({ children, mk }: LastfmP
   }, []);
 
   useEffect(() => {
-    if (mk.mediaItem && mk.mediaItem.item) {
+    if (connected && mk.mediaItem && mk.mediaItem.item) {
       scrobble(mk.mediaItem.item);
     }
   }, [mk.mediaItem]);

--- a/src/app/components/Providers/LastfmProvider.tsx
+++ b/src/app/components/Providers/LastfmProvider.tsx
@@ -4,7 +4,6 @@ import qs from 'qs';
 import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import Alert from 'react-s-alert';
 import withMK from '../../hoc/withMK';
-import useMK from '../../hooks/useMK';
 import translate from '../../utils/translations/Translations';
 
 const MIN_SCROBBLE_SONG_LENGTH_MS = 30000; // Last.fm recommends: 30s
@@ -193,11 +192,6 @@ const LastfmProvider: React.FC<LastfmProviderProps> = ({ children, mk }: LastfmP
     fetchToken();
   }, []);
 
-  useMK({
-    mediaItem: MusicKit.Events.mediaItemDidChange,
-    playbackState: MusicKit.Events.playbackStateDidChange,
-  });
-
   const state: LastfmProviderValue = {
     login,
     reset,
@@ -261,6 +255,7 @@ const LastfmProvider: React.FC<LastfmProviderProps> = ({ children, mk }: LastfmP
 
 const bindings = {
   [MusicKit.Events.mediaItemDidChange]: 'mediaItem',
+  [MusicKit.Events.playbackStateDidChange]: 'playbackState',
 };
 
 export default withMK(LastfmProvider, bindings);


### PR DESCRIPTION
### Only send Last.fm API-requests when the user is connected to Last.fm.
This reduces network-utilization on the user's and Last.fm's end.

### Send a `track.updateNowPlaying` request when a track starts playing.
This will show up on a user's Last.fm profile and is also used by some third-party (Last.fm-connected) apps to track what a user is listening to.

### Send track duration with `updateNowPlaying` and `scrobble` requests.
This tells Last.fm for how long the "Now Playing" status should stay active.
I'm not sure what it does for scrobbles, but they are asking for it nonetheless.

### Follow Last.fm's recommended scrobbling conditions.
>The track must be longer than 30 seconds.
    And the track has been played for at least half its duration, or for 4 minutes (whichever occurs earlier.)

This PR implements the _"track has been played for at least half its duration_ in its literal sense; it tracks how long a track has been actively playing for and scrobbles once that reaches half the track's duration. It doesn't **explicitly** scrobble halfway through the track or `min(duration/2, 4min)` after the track has started playing. It scrobbles once `min(duration/2, 4min)` of **active** play-time is reached on a track.

### Scrobble repeating tracks.
Whether a track is repeated by manually pressing the `<<` button or by toggling the `single-track-repeat` button - it can now be scrobbled anew on every repeat, considering the new scrobble conditions.