### PR TITLE
Upgrade backend's AWS Lambda Node.js runtime to v12

### DIFF
--- a/src/backend/serverless.yml
+++ b/src/backend/serverless.yml
@@ -5,7 +5,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   stage: ${self:custom.secrets.NODE_ENV}
   region: us-east-1
 


### PR DESCRIPTION
## Addresses #501.

### Upgrade the AWS Lambda Node.js runtime from v8.10 to v12.x.
Upgrading dependencies is probably not necessary. I could not find any mentions of our versions of `axios` and `string-similarity` not being supported on later Node versions.
The only time we interface with Node is through the `fs.readFileSync` function and its signature still looks the same - no changes should be necessary.