### PR TITLE
Remove negative margin from Artist and Genre-page header-images

### DIFF
--- a/src/app/components/Routes/Catalog/Artist/ArtistPage.scss
+++ b/src/app/components/Routes/Catalog/Artist/ArtistPage.scss
@@ -14,7 +14,6 @@
   background-color: $placeholder_container_color;
   background-size: cover !important;
   background-position: top center !important;
-  margin: 0 -1.5em;
   height: 275px;
   position: relative;
 

--- a/src/app/components/Routes/Catalog/Browse/Genres/Genre/GenrePage.scss
+++ b/src/app/components/Routes/Catalog/Browse/Genres/Genre/GenrePage.scss
@@ -4,7 +4,6 @@
   background-color: $placeholder_container_color;
   background-size: cover !important;
   background-position: top center !important;
-  margin: 0 -1.5em;
   height: 275px;
   position: relative;
 


### PR DESCRIPTION
### Remove the negative margin and give header-images the same offset from the scrollbar as the other page-content-elements have.

<img width="337" alt="image" src="https://user-images.githubusercontent.com/56790644/91071678-c839a700-e638-11ea-9d6a-5a80205b5b11.png">

Negative margins on header-images on the artist-page and genre-page caused a permanent (could not be removed by enlarging container) and unnecessary vertical scrollbar to appear on the page.

![bug](https://user-images.githubusercontent.com/56790644/91070787-8eb46c00-e637-11ea-8a3c-79418002b785.png)

This bug was introduced with my recent [PR](https://github.com/Musish/Musish/commit/2da79b5f6c644f0902beee3383a58867834fc749) implementing custom scrollbars.
I assume the negative margin was initially applied to enlarge the header-images, but I don't think it is necessary any longer.
